### PR TITLE
upgraded lettuce from 3.2.Final to 3.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <skipTests>true</skipTests>
         <github.site.upload.skip>true</github.site.upload.skip>
         <spinach-release-version>0.1.1</spinach-release-version>
-        <lettuce-version>3.2.Final</lettuce-version>
+        <lettuce-version>3.3.Final</lettuce-version>
         <netty-version>4.0.28.Final</netty-version>
     </properties>
 


### PR DESCRIPTION
When using lettuce 3.3.Final with current spinach 1.1 version, you'll run into runtime `NoSuchMethod` errors due to `CommandHandler` signature incompatibilities.
